### PR TITLE
Check if provided data isn't already parsed

### DIFF
--- a/jquery.json-processor.js
+++ b/jquery.json-processor.js
@@ -28,7 +28,7 @@ JsonProcessor.prototype = {
     properties: {}, //The parsed JSON
 
     /**
-     * Parse the JSON then send it's properties to be filtered for action.
+     * Parse the JSON if needed then send it's properties to be filtered for action.
      *
      * @param json
      */
@@ -36,9 +36,13 @@ JsonProcessor.prototype = {
         if (!json) {
             return;
         }
-        properties = jQuery.parseJSON(json);
+        if (typeof json != 'object') {
+            properties = jQuery.parseJSON(json);
+        } else {
+            properties = json;
+        }
         this.process(properties);
-    },
+    };
 
     /**
      * Filter properties for action.


### PR DESCRIPTION
Hi, i've run into small problem, when trying to use this script with [jquery-ajax-form](https://github.com/incraigulous/jquery-ajax-form), it tries to parse provided data even if it was already parsed, which ends in tears with “Uncaught SyntaxError: Unexpected token o”. 

I use simple workaround, but I think this check should be added by default. 

```
    JsonProcessor.prototype.processJson = function(json) {
        if (!json) {
            return;
        }
        if (typeof json != 'object') {
            properties = jQuery.parseJSON(json);
        } else {
            properties = json;
        }
        this.process(properties);
    };
```

Best regards
